### PR TITLE
Feature/warmup

### DIFF
--- a/src/benchmarks/atomics/shmem_atomic_add.c
+++ b/src/benchmarks/atomics/shmem_atomic_add.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_add
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_add_latency(int ntimes) {
+void bench_shmem_atomic_add_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -52,8 +52,19 @@ void bench_shmem_atomic_add_latency(int ntimes) {
   /* Sync PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_add operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    shmem_atomic_add(&dest[shmem_my_pe()], 1, pe);
+    shmem_quiet(); 
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_add operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -78,7 +89,7 @@ void bench_shmem_atomic_add_latency(int ntimes) {
 
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_add", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   shmem_barrier_all();

--- a/src/benchmarks/atomics/shmem_atomic_add.c
+++ b/src/benchmarks/atomics/shmem_atomic_add.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_add
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_add_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/atomics/shmem_atomic_add.h
+++ b/src/benchmarks/atomics/shmem_atomic_add.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_add
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_add_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_add.h
+++ b/src/benchmarks/atomics/shmem_atomic_add.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_add
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_add_latency(int ntimes);
+void bench_shmem_atomic_add_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_ADD_H */

--- a/src/benchmarks/atomics/shmem_atomic_compare_swap.c
+++ b/src/benchmarks/atomics/shmem_atomic_compare_swap.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_compare_swap
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_compare_swap_latency(int ntimes) {
+void bench_shmem_atomic_compare_swap_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -57,9 +57,20 @@ void bench_shmem_atomic_compare_swap_latency(int ntimes) {
   /* Sync PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_compare_swap operation ntimes and measure latency
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    shmem_atomic_compare_swap(&dest[shmem_my_pe()], 0, 1, pe);
+    shmem_quiet(); 
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_compare_swap operation opts->ntimes and measure latency
    */
-  for (int i = 0; i < ntimes; i++) {
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -84,7 +95,7 @@ void bench_shmem_atomic_compare_swap_latency(int ntimes) {
 
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_compare_swap",
-                                   *total_time / npes, ntimes);
+                                   *total_time / npes, opts->ntimes);
   }
 
   shmem_barrier_all();

--- a/src/benchmarks/atomics/shmem_atomic_compare_swap.c
+++ b/src/benchmarks/atomics/shmem_atomic_compare_swap.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_compare_swap
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_compare_swap_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/atomics/shmem_atomic_compare_swap.h
+++ b/src/benchmarks/atomics/shmem_atomic_compare_swap.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_compare_swap
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_compare_swap_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_compare_swap.h
+++ b/src/benchmarks/atomics/shmem_atomic_compare_swap.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_compare_swap
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_compare_swap_latency(int ntimes);
+void bench_shmem_atomic_compare_swap_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_COMPARE_SWAP_H */

--- a/src/benchmarks/atomics/shmem_atomic_fetch.c
+++ b/src/benchmarks/atomics/shmem_atomic_fetch.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_fetch_latency(int ntimes) {
+void bench_shmem_atomic_fetch_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -48,8 +48,18 @@ void bench_shmem_atomic_fetch_latency(int ntimes) {
   /* Sync PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_fetch operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    *result = shmem_atomic_fetch(&source[shmem_my_pe()], pe);
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_fetch operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -73,7 +83,7 @@ void bench_shmem_atomic_fetch_latency(int ntimes) {
 
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_fetch", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   shmem_barrier_all();

--- a/src/benchmarks/atomics/shmem_atomic_fetch.c
+++ b/src/benchmarks/atomics/shmem_atomic_fetch.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_fetch_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/atomics/shmem_atomic_fetch.h
+++ b/src/benchmarks/atomics/shmem_atomic_fetch.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_fetch_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_fetch.h
+++ b/src/benchmarks/atomics/shmem_atomic_fetch.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_fetch_latency(int ntimes);
+void bench_shmem_atomic_fetch_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_FETCH_H */

--- a/src/benchmarks/atomics/shmem_atomic_fetch_nbi.c
+++ b/src/benchmarks/atomics/shmem_atomic_fetch_nbi.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_fetch_nbi_latency(options * opts) {
 #if defined(USE_15)

--- a/src/benchmarks/atomics/shmem_atomic_fetch_nbi.c
+++ b/src/benchmarks/atomics/shmem_atomic_fetch_nbi.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch_nbi
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_fetch_nbi_latency(int ntimes) {
+void bench_shmem_atomic_fetch_nbi_latency(options * opts) {
 #if defined(USE_15)
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
@@ -38,8 +38,17 @@ void bench_shmem_atomic_fetch_nbi_latency(int ntimes) {
   /* Sync PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_fetch_nbi operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+    shmem_atomic_fetch_nbi(source, &dest[shmem_my_pe()], pe);
+    shmem_quiet();
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_fetch_nbi operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -59,7 +68,7 @@ void bench_shmem_atomic_fetch_nbi_latency(int ntimes) {
 
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_fetch_nbi", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   shmem_barrier_all();

--- a/src/benchmarks/atomics/shmem_atomic_fetch_nbi.h
+++ b/src/benchmarks/atomics/shmem_atomic_fetch_nbi.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch_nbi
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_fetch_nbi_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_fetch_nbi.h
+++ b/src/benchmarks/atomics/shmem_atomic_fetch_nbi.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_fetch_nbi
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_fetch_nbi_latency(int ntimes);
+void bench_shmem_atomic_fetch_nbi_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_FETCH_NBI_H */

--- a/src/benchmarks/atomics/shmem_atomic_inc.c
+++ b/src/benchmarks/atomics/shmem_atomic_inc.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_inc
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_inc_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/atomics/shmem_atomic_inc.c
+++ b/src/benchmarks/atomics/shmem_atomic_inc.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_inc
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_inc_latency(int ntimes) {
+void bench_shmem_atomic_inc_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -54,8 +54,18 @@ void bench_shmem_atomic_inc_latency(int ntimes) {
   /* Sync PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_inc operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    shmem_atomic_inc(&dest[shmem_my_pe()], pe);
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_inc operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -79,7 +89,7 @@ void bench_shmem_atomic_inc_latency(int ntimes) {
 
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_inc", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   shmem_barrier_all();

--- a/src/benchmarks/atomics/shmem_atomic_inc.h
+++ b/src/benchmarks/atomics/shmem_atomic_inc.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_inc
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_inc_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_inc.h
+++ b/src/benchmarks/atomics/shmem_atomic_inc.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_inc
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_inc_latency(int ntimes);
+void bench_shmem_atomic_inc_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_INC_H */

--- a/src/benchmarks/atomics/shmem_atomic_set.c
+++ b/src/benchmarks/atomics/shmem_atomic_set.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_set
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_set_latency(int ntimes) {
+void bench_shmem_atomic_set_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -54,8 +54,18 @@ void bench_shmem_atomic_set_latency(int ntimes) {
   /* Sync PEs before starting benchmark */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_set operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    shmem_atomic_set(&dest[shmem_my_pe()], i, pe);
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_set operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -80,7 +90,7 @@ void bench_shmem_atomic_set_latency(int ntimes) {
   /* Display results if on PE 0 */
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_set", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   /* Barrier for consistency and clean up memory */

--- a/src/benchmarks/atomics/shmem_atomic_set.c
+++ b/src/benchmarks/atomics/shmem_atomic_set.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_set
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_set_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/atomics/shmem_atomic_set.h
+++ b/src/benchmarks/atomics/shmem_atomic_set.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_set
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_set_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_set.h
+++ b/src/benchmarks/atomics/shmem_atomic_set.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_set
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_set_latency(int ntimes);
+void bench_shmem_atomic_set_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_SET_H */

--- a/src/benchmarks/atomics/shmem_atomic_swap.c
+++ b/src/benchmarks/atomics/shmem_atomic_swap.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_swap
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_swap_latency(options * opts) {
   /* Check if there are enough PEs to run the benchmark */

--- a/src/benchmarks/atomics/shmem_atomic_swap.c
+++ b/src/benchmarks/atomics/shmem_atomic_swap.c
@@ -8,9 +8,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_swap
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_atomic_swap_latency(int ntimes) {
+void bench_shmem_atomic_swap_latency(options * opts) {
   /* Check if there are enough PEs to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -54,8 +54,18 @@ void bench_shmem_atomic_swap_latency(int ntimes) {
   /* Synchronize all PEs */
   shmem_barrier_all();
 
-  /* Perform the shmem_atomic_swap operation ntimes and measure latency */
-  for (int i = 0; i < ntimes; i++) {
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    int pe = rand() % npes; 
+#if defined(USE_14) || defined(USE_15)
+    shmem_atomic_swap(&dest[shmem_my_pe()], i, pe);
+#endif
+  }
+
+  shmem_barrier_all();
+
+  /* Perform the shmem_atomic_swap operation opts->ntimes and measure latency */
+  for (int i = 0; i < opts->ntimes; i++) {
     int pe = rand() % npes; /* Randomly select a target PE */
     double start_time = mysecond();
 
@@ -80,7 +90,7 @@ void bench_shmem_atomic_swap_latency(int ntimes) {
   /* Display results on PE 0 */
   if (shmem_my_pe() == 0) {
     display_atomic_latency_results("shmem_atomic_swap", *total_time / npes,
-                                   ntimes);
+                                   opts->ntimes);
   }
 
   /* Final synchronization and cleanup */

--- a/src/benchmarks/atomics/shmem_atomic_swap.h
+++ b/src/benchmarks/atomics/shmem_atomic_swap.h
@@ -18,7 +18,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_atomic_swap
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_atomic_swap_latency(options * opts);
 

--- a/src/benchmarks/atomics/shmem_atomic_swap.h
+++ b/src/benchmarks/atomics/shmem_atomic_swap.h
@@ -14,11 +14,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_atomic_swap
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_atomic_swap_latency(int ntimes);
+void bench_shmem_atomic_swap_latency(options * opts);
 
 #endif /* SHMEM_ATOMIC_SWAP_H */

--- a/src/benchmarks/collectives/shmem_alltoall.c
+++ b/src/benchmarks/collectives/shmem_alltoall.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoall
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoall_bw(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/collectives/shmem_alltoall.c
+++ b/src/benchmarks/collectives/shmem_alltoall.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoall
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_alltoall_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of PEs and PE number */
@@ -41,7 +39,7 @@ void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes) {
 #endif
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -64,16 +62,27 @@ void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Start timer */
-    start_time = mysecond();
-
-    /* Perform NTIMES shmem_alltoall operations */
-    for (int j = 0; j < ntimes; j++) {
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
 #if defined(USE_14)
       shmem_alltoall64(dest, source, elem_count, 0, 0, npes, pSync);
 #elif defined(USE_15)
       shmem_alltoall(SHMEM_TEAM_WORLD, dest, source, elem_count);
-#endif
+#endif 
+    }
+
+    shmem_barrier_all();
+
+    /* Start timer */
+    start_time = mysecond();
+
+    /* Perform NTIMES shmem_alltoall operations */
+    for (int j = 0; j < opts->ntimes; j++) {
+#if defined(USE_14)
+      shmem_alltoall64(dest, source, elem_count, 0, 0, npes, pSync);
+#elif defined(USE_15)
+      shmem_alltoall(SHMEM_TEAM_WORLD, dest, source, elem_count);
+#endif 
     }
     shmem_quiet();
 
@@ -81,7 +90,7 @@ void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(valid_size * npes, times[i]);

--- a/src/benchmarks/collectives/shmem_alltoall.h
+++ b/src/benchmarks/collectives/shmem_alltoall.h
@@ -17,9 +17,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoall
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoall_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_alltoall.h
+++ b/src/benchmarks/collectives/shmem_alltoall.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoall
@@ -20,6 +21,6 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_alltoall_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_alltoall_bw(options * opts);
 
 #endif /* SHMEM_ALLTOALL_H */

--- a/src/benchmarks/collectives/shmem_alltoallmem.c
+++ b/src/benchmarks/collectives/shmem_alltoallmem.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_alltoallmem_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of PEs and PE number */
@@ -32,7 +30,7 @@ void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
   int mype = shmem_my_pe();
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -51,11 +49,20 @@ void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_15)
+      shmem_alltoallmem(SHMEM_TEAM_WORLD, dest, source, size);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform NTIMES shmem_alltoall operations */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_15)
       shmem_alltoallmem(SHMEM_TEAM_WORLD, dest, source, size);
 #endif
@@ -66,7 +73,7 @@ void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(size * npes, times[i]);

--- a/src/benchmarks/collectives/shmem_alltoallmem.c
+++ b/src/benchmarks/collectives/shmem_alltoallmem.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallmem
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoallmem_bw(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/collectives/shmem_alltoallmem.h
+++ b/src/benchmarks/collectives/shmem_alltoallmem.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallmem
@@ -20,6 +21,6 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of iterations for the benchmark
  */
-void bench_shmem_alltoallmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_alltoallmem_bw(options * opts);
 
 #endif /* SHMEM_ALLTOALLMEM_H */

--- a/src/benchmarks/collectives/shmem_alltoallmem.h
+++ b/src/benchmarks/collectives/shmem_alltoallmem.h
@@ -17,9 +17,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of iterations for the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoallmem_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_alltoalls.c
+++ b/src/benchmarks/collectives/shmem_alltoalls.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoalls
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_alltoalls_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) and PE number */
@@ -41,7 +39,7 @@ void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
 #endif
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -50,8 +48,8 @@ void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
     /* Allocate memory for source and destination arrays */
-    long *source = (long *)shmem_malloc(elem_count * npes * sizeof(long));
-    long *dest = (long *)shmem_malloc(elem_count * npes * sizeof(long));
+    long *source = (long *)shmem_malloc(elem_count * npes * sizeof(long) * opts->stride);
+    long *dest = (long *)shmem_malloc(elem_count * npes * sizeof(long) * opts->stride);
 
     /* Initialize the source buffer with data */
     for (int j = 0; j < elem_count * npes; j++) {
@@ -64,15 +62,26 @@ void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14)
+      shmem_alltoalls64(dest, source, 1, elem_count, elem_count, 0, 0, npes, pSync);
+#elif defined(USE_15)
+      shmem_alltoalls(SHMEM_TEAM_WORLD, dest, source, opts->stride, opts->stride, elem_count);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform NTIMES shmem_alltoalls operations */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14)
       shmem_alltoalls64(dest, source, 1, elem_count, elem_count, 0, 0, npes, pSync);
 #elif defined(USE_15)
-      shmem_alltoalls(SHMEM_TEAM_WORLD, dest, source, 1, elem_count, elem_count);
+      shmem_alltoalls(SHMEM_TEAM_WORLD, dest, source, opts->stride, opts->stride, elem_count);
 #endif
     }
     shmem_quiet();
@@ -81,7 +90,7 @@ void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate the average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(valid_size * npes, times[i]);

--- a/src/benchmarks/collectives/shmem_alltoalls.c
+++ b/src/benchmarks/collectives/shmem_alltoalls.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoalls
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoalls_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_alltoalls.h
+++ b/src/benchmarks/collectives/shmem_alltoalls.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoalls
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoalls_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_alltoalls.h
+++ b/src/benchmarks/collectives/shmem_alltoalls.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoalls
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of times the benchmark should run
  */
-void bench_shmem_alltoalls_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_alltoalls_bw(options * opts);
 
 #endif /* SHMEM_ALLTOALLS_H */

--- a/src/benchmarks/collectives/shmem_alltoallsmem.c
+++ b/src/benchmarks/collectives/shmem_alltoallsmem.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallsmem
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoallsmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_alltoallsmem.c
+++ b/src/benchmarks/collectives/shmem_alltoallsmem.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallsmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_alltoallsmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes)
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) and PE number */
@@ -32,13 +30,13 @@ void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes)
   int mype = shmem_my_pe();
 
   /* Run through the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
     /* Allocate memory for source and destination arrays */
-    unsigned char *source = (unsigned char *)shmem_malloc(size * npes);
-    unsigned char *dest = (unsigned char *)shmem_malloc(size * npes);
+    unsigned char *source = (unsigned char *)shmem_malloc(size * npes * opts->stride);
+    unsigned char *dest = (unsigned char *)shmem_malloc(size * npes * opts->stride);
 
     /* Initialize the source buffer with data */
     for (int j = 0; j < size * npes; j++) {
@@ -51,13 +49,22 @@ void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes)
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_15)
+      shmem_alltoallsmem(SHMEM_TEAM_WORLD, dest, source, opts->stride, opts->stride, size);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform NTIMES shmem_alltoallsmem operations */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_15)
-      shmem_alltoallsmem(SHMEM_TEAM_WORLD, dest, source, 1, size, size);
+      shmem_alltoallsmem(SHMEM_TEAM_WORLD, dest, source, opts->stride, opts->stride, size);
 #endif
     }
     shmem_quiet();
@@ -66,7 +73,7 @@ void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes)
     end_time = mysecond();
 
     /* Calculate the average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(size * npes, times[i]);

--- a/src/benchmarks/collectives/shmem_alltoallsmem.h
+++ b/src/benchmarks/collectives/shmem_alltoallsmem.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallsmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_alltoallsmem_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_alltoallsmem.h
+++ b/src/benchmarks/collectives/shmem_alltoallsmem.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_alltoallsmem
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of times the benchmark should run
  */
-void bench_shmem_alltoallsmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_alltoallsmem_bw(options * opts);
 
 #endif /* SHMEM_ALLTOALLSMEM_H */

--- a/src/benchmarks/collectives/shmem_barrier_all.c
+++ b/src/benchmarks/collectives/shmem_barrier_all.c
@@ -7,9 +7,9 @@
 
 /**
   @brief Run the latency benchmark for shmem_barrier_all
-  @param ntimes Number of times to repeat the operation
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_barrier_all_latency(int ntimes) {
+void bench_shmem_barrier_all_latency(options * opts) {
   if (!check_if_atleast_2_pes()) {
     return;
   }
@@ -20,16 +20,23 @@ void bench_shmem_barrier_all_latency(int ntimes) {
   /* Sync all PEs before starting the timer */
   shmem_barrier_all();
 
+  /* Do warmup runs */
+  for (int i = 0; i < opts->warmups; i++) {
+    shmem_barrier_all();
+  }
+
+  shmem_barrier_all();
+
   start_time = mysecond();
 
-  for (int i = 0; i < ntimes; i++) {
+  for (int i = 0; i < opts->ntimes; i++) {
     shmem_barrier_all();
   }
 
   end_time = mysecond();
 
   total_time = (end_time - start_time) * 1e6;
-  avg_time = total_time / ntimes;
+  avg_time = total_time / opts->ntimes;
 
   shmem_barrier_all();
   if (shmem_my_pe() == 0) {
@@ -37,7 +44,7 @@ void bench_shmem_barrier_all_latency(int ntimes) {
     printf("===        shmem_barrier_all Latency       ===\n");
     printf("==============================================\n");
     printf("Avg Time per Barrier (us): %.2f\n", avg_time);
-    printf("Total Time for %d Barriers (us): %.2f\n", ntimes, total_time);
+    printf("Total Time for %d Barriers (us): %.2f\n", opts->ntimes, total_time);
     printf("==============================================\n\n");
   }
 

--- a/src/benchmarks/collectives/shmem_barrier_all.c
+++ b/src/benchmarks/collectives/shmem_barrier_all.c
@@ -7,7 +7,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_barrier_all
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_barrier_all_latency(options * opts) {
   if (!check_if_atleast_2_pes()) {

--- a/src/benchmarks/collectives/shmem_barrier_all.h
+++ b/src/benchmarks/collectives/shmem_barrier_all.h
@@ -13,11 +13,12 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the latency benchmark for shmem_barrier_all
   @param ntimes Number of times to repeat the operation
  */
-void bench_shmem_barrier_all_latency(int ntimes);
+void bench_shmem_barrier_all_latency(options * opts);
 
 #endif /* SHMEM_BARRIER_ALL_H */

--- a/src/benchmarks/collectives/shmem_barrier_all.h
+++ b/src/benchmarks/collectives/shmem_barrier_all.h
@@ -17,7 +17,7 @@
 
 /**
   @brief Run the latency benchmark for shmem_barrier_all
-  @param ntimes Number of times to repeat the operation
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_barrier_all_latency(options * opts);
 

--- a/src/benchmarks/collectives/shmem_broadcast.c
+++ b/src/benchmarks/collectives/shmem_broadcast.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcast
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_broadcast_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
 #if defined(USE_14)
@@ -40,7 +38,7 @@ void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes) {
 #endif
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -62,12 +60,23 @@ void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14)
+      shmem_broadcast64(dest, source, elem_count, 0, 0, 0, npes, pSync);
+#elif defined(USE_15)
+      shmem_broadcast(SHMEM_TEAM_WORLD, dest, source, elem_count, 0);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_broadcast operation for the specified number of times
      */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14)
       shmem_broadcast64(dest, source, elem_count, 0, 0, 0, npes, pSync);
 #elif defined(USE_15)
@@ -80,7 +89,7 @@ void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
       
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(valid_size, times[i]);

--- a/src/benchmarks/collectives/shmem_broadcast.c
+++ b/src/benchmarks/collectives/shmem_broadcast.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcast
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_broadcast_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_broadcast.h
+++ b/src/benchmarks/collectives/shmem_broadcast.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcast
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_broadcast_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_broadcast.h
+++ b/src/benchmarks/collectives/shmem_broadcast.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcast
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_broadcast_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_broadcast_bw(options * opts);
 
 #endif /* SHMEM_BROADCAST_H */

--- a/src/benchmarks/collectives/shmem_broadcastmem.c
+++ b/src/benchmarks/collectives/shmem_broadcastmem.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcastmem
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_broadcastmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_broadcastmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,11 +22,11 @@ void bench_shmem_broadcastmem_bw(int min_msg_size, int max_msg_size, int ntimes)
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -46,12 +44,21 @@ void bench_shmem_broadcastmem_bw(int min_msg_size, int max_msg_size, int ntimes)
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_15)
+      shmem_broadcastmem(SHMEM_TEAM_WORLD, dest, source, size, 0);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_broadcastmem operation for the specified number of times
      */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_15)
       shmem_broadcastmem(SHMEM_TEAM_WORLD, dest, source, size, 0);
 #endif
@@ -62,7 +69,7 @@ void bench_shmem_broadcastmem_bw(int min_msg_size, int max_msg_size, int ntimes)
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(size, times[i]);

--- a/src/benchmarks/collectives/shmem_broadcastmem.c
+++ b/src/benchmarks/collectives/shmem_broadcastmem.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcastmem
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_broadcastmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_broadcastmem.h
+++ b/src/benchmarks/collectives/shmem_broadcastmem.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcastmem
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_broadcastmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_broadcastmem_bw(options * opts);
 
 #endif /* SHMEM_BROADCASTMEM_H */

--- a/src/benchmarks/collectives/shmem_broadcastmem.h
+++ b/src/benchmarks/collectives/shmem_broadcastmem.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_broadcastmem
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_broadcastmem_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_collect.c
+++ b/src/benchmarks/collectives/shmem_collect.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_collect_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_collect.c
+++ b/src/benchmarks/collectives/shmem_collect.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_collect_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) and PE number */
@@ -40,7 +38,7 @@ void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes) {
 #endif
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -62,11 +60,22 @@ void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14)
+      shmem_collect64(dest, source, elem_count, 0, 0, npes, pSync);
+#elif defined(USE_15)
+      shmem_collect(SHMEM_TEAM_WORLD, dest, source, elem_count);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_collect operation for the specified number of times */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14)
       shmem_collect64(dest, source, elem_count, 0, 0, npes, pSync);
 #elif defined(USE_15)
@@ -79,7 +88,7 @@ void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth*/
     bandwidths[i] = calculate_bw(valid_size, times[i]);

--- a/src/benchmarks/collectives/shmem_collect.h
+++ b/src/benchmarks/collectives/shmem_collect.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_collect_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_collect.h
+++ b/src/benchmarks/collectives/shmem_collect.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_collect_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_collect_bw(options * opts);
 
 #endif /* SHMEM_COLLECT_H */

--- a/src/benchmarks/collectives/shmem_collectmem.c
+++ b/src/benchmarks/collectives/shmem_collectmem.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collectmem
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_collectmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_collectmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,14 +22,14 @@ void bench_shmem_collectmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) and PE number */
   int npes = shmem_n_pes();
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save the message size */
     msg_sizes[i] = size;
 
@@ -49,11 +47,20 @@ void bench_shmem_collectmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_15)
+      shmem_collectmem(SHMEM_TEAM_WORLD, dest, source, size);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_collectmem operation for the specified number of times */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_15)
       shmem_collectmem(SHMEM_TEAM_WORLD, dest, source, size);
 #endif
@@ -64,7 +71,7 @@ void bench_shmem_collectmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth*/
     bandwidths[i] = calculate_bw(size, times[i]);

--- a/src/benchmarks/collectives/shmem_collectmem.c
+++ b/src/benchmarks/collectives/shmem_collectmem.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collectmem
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_collectmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_collectmem.h
+++ b/src/benchmarks/collectives/shmem_collectmem.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_collectmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_collectmem_bw(options * opts);
 
 #endif /* SHMEM_COLLECTMEM_H */

--- a/src/benchmarks/collectives/shmem_collectmem.h
+++ b/src/benchmarks/collectives/shmem_collectmem.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_collect
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_collectmem_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_fcollect.c
+++ b/src/benchmarks/collectives/shmem_fcollect.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollect
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_fcollect_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,7 +22,7 @@ void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) */
@@ -40,7 +38,7 @@ void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes) {
 #endif
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -63,11 +61,22 @@ void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14)
+      shmem_fcollect64(dest, source, elem_count, 0, 0, npes, pSync);
+#elif defined(USE_15)
+      shmem_fcollect(SHMEM_TEAM_WORLD, dest, source, elem_count);
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_fcollect operation for the specified number of times */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14)
       shmem_fcollect64(dest, source, elem_count, 0, 0, npes, pSync);
 #elif defined(USE_15)
@@ -80,7 +89,7 @@ void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(valid_size, times[i]);

--- a/src/benchmarks/collectives/shmem_fcollect.c
+++ b/src/benchmarks/collectives/shmem_fcollect.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollect
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_fcollect_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_fcollect.h
+++ b/src/benchmarks/collectives/shmem_fcollect.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollect
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_fcollect_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_fcollect.h
+++ b/src/benchmarks/collectives/shmem_fcollect.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollect
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_fcollect_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_fcollect_bw(options * opts);
 
 #endif /* SHMEM_FCOLLECT_H */

--- a/src/benchmarks/collectives/shmem_fcollectmem.c
+++ b/src/benchmarks/collectives/shmem_fcollectmem.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollectmem
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_fcollectmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */

--- a/src/benchmarks/collectives/shmem_fcollectmem.c
+++ b/src/benchmarks/collectives/shmem_fcollectmem.c
@@ -8,11 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollectmem
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_fcollectmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_fcollectmem_bw(options * opts) {
   /* Ensure there are at least 2 PEs available to run the benchmark */
   if (!check_if_atleast_2_pes()) {
     return;
@@ -24,14 +22,14 @@ void bench_shmem_fcollectmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
   int num_sizes = 0;
 
   /* Setup benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Get the number of processing elements (PEs) */
   int npes = shmem_n_pes();
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     msg_sizes[i] = size;
 
     /* Source array for shmem_fcollect */
@@ -49,11 +47,20 @@ void bench_shmem_fcollectmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_15)
+      shmem_fcollect(SHMEM_TEAM_WORLD, dest, source, size);
+#endif
+    }
+    
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform the shmem_fcollect operation for the specified number of times */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_15)
       shmem_fcollect(SHMEM_TEAM_WORLD, dest, source, size);
 #endif
@@ -64,7 +71,7 @@ void bench_shmem_fcollectmem_bw(int min_msg_size, int max_msg_size, int ntimes) 
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth */
     bandwidths[i] = calculate_bw(size, times[i]);

--- a/src/benchmarks/collectives/shmem_fcollectmem.h
+++ b/src/benchmarks/collectives/shmem_fcollectmem.h
@@ -18,9 +18,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollectmem
-  @param min_msg_size Minimum message size for the test in bytes
-  @param max_msg_size Maximum message size for the test in bytes
-  @param ntimes Number of times to run the benchmark
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_fcollectmem_bw(options * opts);
 

--- a/src/benchmarks/collectives/shmem_fcollectmem.h
+++ b/src/benchmarks/collectives/shmem_fcollectmem.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_fcollectmem
@@ -21,6 +22,6 @@
   @param max_msg_size Maximum message size for the test in bytes
   @param ntimes Number of times to run the benchmark
  */
-void bench_shmem_fcollectmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_fcollectmem_bw(options * opts);
 
 #endif /* SHMEM_FCOLLECTMEM_H */

--- a/src/benchmarks/rma/shmem_get.c
+++ b/src/benchmarks/rma/shmem_get.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts benchmark options given by user 
  */
-void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_get_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate and adjust the message size to be compatible with long type */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -52,13 +50,22 @@ void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup rounds */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_get(dest, source, elem_count, 1);
+#endif
+      }
+    }
+
     /* Start timer */
     start_time = mysecond();
 
     /* Perform ntimes shmem_gets with P0 */
     if (mype == 0) {
       /* Perform ntimes shmem_gets */
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_get(dest, source, elem_count, 1);
 #endif
@@ -69,7 +76,7 @@ void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using actual bytes transferred */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -97,11 +104,9 @@ void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the bidirectional bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts benchmark options given by user 
  *************************************************************/
-void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_get_bibw(options *opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -116,11 +121,11 @@ void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate and adjust the message size to be compatible with long type */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -147,7 +152,7 @@ void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     start_time = mysecond();
 
     /* Perform ntimes bidirectional shmem_gets */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_get(dest, source, elem_count, peer); /* each PE gets from other PE */
 #endif
@@ -157,7 +162,7 @@ void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
     /* Calculate bidirectional bandwidth using actual bytes transferred */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
 
@@ -184,11 +189,9 @@ void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+ @param opts benchmark options given by user 
  *************************************************************/
-void bench_shmem_get_latency(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_get_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -202,11 +205,11 @@ void bench_shmem_get_latency(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate and adjust the message size to be compatible with long type */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -231,7 +234,7 @@ void bench_shmem_get_latency(int min_msg_size, int max_msg_size, int ntimes) {
 
     /* Perform ntimes shmem_gets and accumulate total time */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_get(dest, source, elem_count, 1);
@@ -242,7 +245,7 @@ void bench_shmem_get_latency(int min_msg_size, int max_msg_size, int ntimes) {
     }
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_get.h
+++ b/src/benchmarks/rma/shmem_get.h
@@ -7,6 +7,7 @@
 #define _SHMEM_GET_H_
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_get
@@ -14,7 +15,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_get_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get
@@ -22,6 +23,6 @@ void bench_shmem_get_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_get_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_get_bibw(options * opts);
 
 #endif /* _SHMEM_GET_H_ */

--- a/src/benchmarks/rma/shmem_get.h
+++ b/src/benchmarks/rma/shmem_get.h
@@ -11,17 +11,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_get_nbi.c
+++ b/src/benchmarks/rma/shmem_get_nbi.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_get_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -52,12 +50,23 @@ void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_get_nbi(dest, source, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_get_nbis */
+    /* Perform opts->ntimes shmem_get_nbis */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_get_nbi(dest, source, elem_count, 1);
         shmem_quiet();
@@ -72,7 +81,7 @@ void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     shmem_barrier_all();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -97,11 +106,9 @@ void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_get_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -116,11 +123,11 @@ void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -143,11 +150,21 @@ void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_get_nbi(dest, source, elem_count, peer); /* each PE gets from other PE */
+      shmem_quiet();
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_get_nbis */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_get_nbis */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_get_nbi(dest, source, elem_count, peer); /* each PE gets from other PE */
       shmem_quiet();
@@ -161,7 +178,7 @@ void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     shmem_barrier_all();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
@@ -186,12 +203,9 @@ void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  *************************************************************/
-void bench_shmem_get_nbi_latency(int min_msg_size, int max_msg_size,
-                                 int ntimes) {
+void bench_shmem_get_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -205,11 +219,11 @@ void bench_shmem_get_nbi_latency(int min_msg_size, int max_msg_size,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -232,9 +246,21 @@ void bench_shmem_get_nbi_latency(int min_msg_size, int max_msg_size,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_get_nbis and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_get_nbi(dest, source, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+    
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_get_nbis and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_get_nbi(dest, source, elem_count, 1);
@@ -249,7 +275,7 @@ void bench_shmem_get_nbi_latency(int min_msg_size, int max_msg_size,
     shmem_barrier_all();
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_get_nbi.c
+++ b/src/benchmarks/rma/shmem_get_nbi.c
@@ -7,7 +7,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -106,7 +106,7 @@ void bench_shmem_get_nbi_bw(options * opts) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -203,7 +203,7 @@ void bench_shmem_get_nbi_bibw(options * opts) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_get_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  *************************************************************/
 void bench_shmem_get_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/rma/shmem_get_nbi.h
+++ b/src/benchmarks/rma/shmem_get_nbi.h
@@ -17,17 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_get_nbi_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_get_nbi.h
+++ b/src/benchmarks/rma/shmem_get_nbi.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_get_nbi
@@ -20,7 +21,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_get_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get_nbi
@@ -28,6 +29,6 @@ void bench_shmem_get_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_get_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_get_nbi_bibw(options * opts);
 
 #endif /* SHMEM_GET_NBI_H */

--- a/src/benchmarks/rma/shmem_getmem.c
+++ b/src/benchmarks/rma/shmem_getmem.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_getmem_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -47,13 +45,24 @@ void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
     /* Sync PEs */
     shmem_barrier_all();
+    
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_getmem(dest, source, size, 1);
+#endif
+      }
+    }
+
+    shmem_barrier_all();
 
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_getmems with P0 */
+    /* Perform opts->ntimes shmem_getmems with P0 */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_getmem(dest, source, size, 1);
 #endif
@@ -64,7 +73,7 @@ void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using actual bytes transferred */
     bandwidths[i] = calculate_bw(size, times[i]);
@@ -92,11 +101,9 @@ void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the bidirectional bandwidth benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  *************************************************************/
-void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_getmem_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -111,11 +118,11 @@ void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -134,11 +141,20 @@ void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_getmem(dest, source, size, peer); /* each PE gets from other PE */
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_getmems */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_getmems */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_getmem(dest, source, size, peer); /* each PE gets from other PE */
 #endif
@@ -148,7 +164,7 @@ void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
     /* Calculate bidirectional bandwidth using actual bytes transferred */
     bandwidths[i] = calculate_bibw(size, times[i]);
 
@@ -175,11 +191,9 @@ void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_get
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  *************************************************************/
-void bench_shmem_getmem_latency(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_getmem_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -193,11 +207,11 @@ void bench_shmem_getmem_latency(int min_msg_size, int max_msg_size, int ntimes) 
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size and allocate byte buffers */
     msg_sizes[i] = size;
 
@@ -216,9 +230,20 @@ void bench_shmem_getmem_latency(int min_msg_size, int max_msg_size, int ntimes) 
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_gets and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_getmem(dest, source, size, 1);
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_gets and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_getmem(dest, source, size, 1);
@@ -229,7 +254,7 @@ void bench_shmem_getmem_latency(int min_msg_size, int max_msg_size, int ntimes) 
     }
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_getmem.h
+++ b/src/benchmarks/rma/shmem_getmem.h
@@ -11,17 +11,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_getmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_getmem_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_getmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_getmem_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_getmem.h
+++ b/src/benchmarks/rma/shmem_getmem.h
@@ -7,6 +7,7 @@
 #define _SHMEM_GETMEM_H_
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_getmem
@@ -14,7 +15,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_getmem_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_getmem
@@ -22,6 +23,6 @@ void bench_shmem_getmem_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_getmem_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_getmem_bibw(options * opts);
 
 #endif /* _SHMEM_GETMEM_H_ */

--- a/src/benchmarks/rma/shmem_getmem_nbi.c
+++ b/src/benchmarks/rma/shmem_getmem_nbi.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_getmem_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -47,12 +45,24 @@ void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_getmem_nbi(dest, source, size, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_getmem_nbis */
+    /* Perform opts->ntimes shmem_getmem_nbis */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_getmem_nbi(dest, source, size, 1);
         shmem_quiet();
@@ -67,7 +77,7 @@ void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     shmem_barrier_all();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(size, times[i]);
@@ -92,11 +102,9 @@ void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_getmem_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -111,11 +119,11 @@ void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -132,12 +140,22 @@ void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
 
     /* Sync PEs */
     shmem_barrier_all();
+    
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_getmem_nbi(dest, source, size, peer); 
+      shmem_quiet();
+#endif
+    }
+
+    shmem_barrier_all();
 
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_getmem_nbis */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_getmem_nbis */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_getmem_nbi(dest, source, size, peer); /* each PE gets from other PE */
       shmem_quiet();
@@ -151,7 +169,7 @@ void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
     shmem_barrier_all();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(size, times[i]);
@@ -176,12 +194,9 @@ void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_get_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  *************************************************************/
-void bench_shmem_getmem_nbi_latency(int min_msg_size, int max_msg_size,
-                                 int ntimes) {
+void bench_shmem_getmem_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -195,11 +210,11 @@ void bench_shmem_getmem_nbi_latency(int min_msg_size, int max_msg_size,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -222,9 +237,21 @@ void bench_shmem_getmem_nbi_latency(int min_msg_size, int max_msg_size,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_get_nbis and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_get_nbi(dest, source, size, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_get_nbis and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_get_nbi(dest, source, size, 1);
@@ -239,7 +266,7 @@ void bench_shmem_getmem_nbi_latency(int min_msg_size, int max_msg_size,
     shmem_barrier_all();
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_getmem_nbi.h
+++ b/src/benchmarks/rma/shmem_getmem_nbi.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_getmem_nbi
@@ -20,7 +21,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_getmem_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_getmem_nbi
@@ -28,6 +29,6 @@ void bench_shmem_getmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_getmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_getmem_nbi_bibw(options * opts);
 
 #endif /* SHMEM_GETMEM_NBI_H */

--- a/src/benchmarks/rma/shmem_getmem_nbi.h
+++ b/src/benchmarks/rma/shmem_getmem_nbi.h
@@ -17,17 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_getmem_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_getmem_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_getmem_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_getmem_nbi_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_iget.c
+++ b/src/benchmarks/rma/shmem_iget.c
@@ -8,7 +8,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_iget
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_iget_bw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -106,7 +106,7 @@ void bench_shmem_iget_bw(options * opts) {
 
 /*************************************************************
   @brief Run the bidirectional bandwidth benchmark for shmem_iget
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  *************************************************************/
 void bench_shmem_iget_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -201,7 +201,7 @@ void bench_shmem_iget_bibw(options * opts) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_iget
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  *************************************************************/
 void bench_shmem_iget_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/rma/shmem_iget.c
+++ b/src/benchmarks/rma/shmem_iget.c
@@ -8,13 +8,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_iget
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iget
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
-                         int stride) {
+void bench_shmem_iget_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -28,11 +24,11 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -40,12 +36,12 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
     }
 
@@ -55,14 +51,25 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_iget(dest, source, 1, opts->stride, elem_count, 1);
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_igets */
+    /* Perform opts->ntimes shmem_igets */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
-        shmem_iget(dest, source, 1, stride, elem_count, 1);
+        shmem_iget(dest, source, 1, opts->stride, elem_count, 1);
 #endif
       }
     }
@@ -71,7 +78,7 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -99,13 +106,9 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
 
 /*************************************************************
   @brief Run the bidirectional bandwidth benchmark for shmem_iget
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride between consecutive elements
+  @param opts Benchmarks options given by the user 
  *************************************************************/
-void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
-                           int stride) {
+void bench_shmem_iget_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -120,11 +123,11 @@ void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -132,12 +135,12 @@ void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
       dest[j] = j;
     }
@@ -148,13 +151,21 @@ void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_iget(dest, source, 1, opts->stride, elem_count, peer); /* each PE sends to other PE */
+#endif
+    }
+ 
+    shmem_barrier_all();
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_igets */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_igets */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
-      shmem_iget(dest, source, 1, stride, elem_count, peer); /* each PE sends to other PE */
+      shmem_iget(dest, source, 1, opts->stride, elem_count, peer); /* each PE sends to other PE */
 #endif
     }
 
@@ -162,7 +173,7 @@ void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
@@ -190,13 +201,9 @@ void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_iget
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride between consecutive elements
+  @param opts Benchmarks options given by the user 
  *************************************************************/
-void bench_shmem_iget_latency(int min_msg_size, int max_msg_size, int ntimes,
-                              int stride) {
+void bench_shmem_iget_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -210,11 +217,11 @@ void bench_shmem_iget_latency(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -222,12 +229,12 @@ void bench_shmem_iget_latency(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count *  stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count *  opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
     }
 
@@ -237,12 +244,23 @@ void bench_shmem_iget_latency(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_igets and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_iget(dest, source, 1, opts->stride, elem_count, 1);
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_igets and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
-        shmem_iget(dest, source, 1, stride, elem_count, 1);
+        shmem_iget(dest, source, 1, opts->stride, elem_count, 1);
 #endif
         double end_time = mysecond();
         total_time += (end_time - start_time) * 1e6;
@@ -250,7 +268,7 @@ void bench_shmem_iget_latency(int min_msg_size, int max_msg_size, int ntimes,
     }
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_iget.h
+++ b/src/benchmarks/rma/shmem_iget.h
@@ -17,19 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_iget
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iget
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_iget_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_iget
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iget
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_iget_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_iget.h
+++ b/src/benchmarks/rma/shmem_iget.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_iget
@@ -21,8 +22,7 @@
   @param ntimes Number of repetitions to get the avgs from
   @param stride Stride for shmem_iget
  */
-void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
-                         int stride);
+void bench_shmem_iget_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_iget
@@ -31,7 +31,6 @@ void bench_shmem_iget_bw(int min_msg_size, int max_msg_size, int ntimes,
   @param ntimes Number of repetitions to get the avgs from
   @param stride Stride for shmem_iget
  */
-void bench_shmem_iget_bibw(int min_msg_size, int max_msg_size, int ntimes,
-                           int stride);
+void bench_shmem_iget_bibw(options * opts);
 
 #endif /* SHMEM_IGET_H */

--- a/src/benchmarks/rma/shmem_iput.c
+++ b/src/benchmarks/rma/shmem_iput.c
@@ -7,13 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_iput
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iput
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
-                         int stride) {
+void bench_shmem_iput_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -27,11 +23,11 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -39,12 +35,12 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
     }
 
@@ -54,14 +50,26 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0)  {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_iput(dest, source, 1, opts->stride, elem_count, 1);
+        shmem_fence();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_iputs */
+    /* Perform opts->ntimes shmem_iputs */
     if (mype == 0)  {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
-        shmem_iput(dest, source, 1, stride, elem_count, 1);
+        shmem_iput(dest, source, 1, opts->stride, elem_count, 1);
         shmem_fence();
 #endif
       }
@@ -72,7 +80,7 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -100,13 +108,9 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_iput
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride between consecutive elements
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
-                           int stride) {
+void bench_shmem_iput_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -121,11 +125,11 @@ void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -133,12 +137,12 @@ void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
       dest[j] = j;
     }
@@ -149,13 +153,22 @@ void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_iput(dest, source, 1, opts->stride, elem_count, peer); 
+      shmem_fence();
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_iputs */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_iputs */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
-      shmem_iput(dest, source, 1, stride, elem_count, peer); /* each PE sends to other PE */
+      shmem_iput(dest, source, 1, opts->stride, elem_count, peer); /* each PE sends to other PE */
       shmem_fence();
 #endif
     }
@@ -165,7 +178,7 @@ void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
@@ -193,13 +206,9 @@ void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_iput
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride between consecutive elements
+  @param opts Benchmark options given by user 
  *************************************************************/
-void bench_shmem_iput_latency(int min_msg_size, int max_msg_size, int ntimes,
-                              int stride) {
+void bench_shmem_iput_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -213,11 +222,11 @@ void bench_shmem_iput_latency(int min_msg_size, int max_msg_size, int ntimes,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -225,12 +234,12 @@ void bench_shmem_iput_latency(int min_msg_size, int max_msg_size, int ntimes,
     /* Calculate the number of elements based on the validated size */
     int elem_count = calculate_elem_count(valid_size, sizeof(long));
 
-    /* Source and destination arrays plus additional size for stride */
-    long *source = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
-    long *dest = (long *)shmem_malloc((elem_count * stride) * sizeof(long));
+    /* Source and destination arrays plus additional size for opts->stride */
+    long *source = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
+    long *dest = (long *)shmem_malloc((elem_count * opts->stride) * sizeof(long));
 
     /* Initialize source buffer */
-    for (int j = 0; j < elem_count * stride; j++) {
+    for (int j = 0; j < elem_count * opts->stride; j++) {
       source[j] = j;
     }
 
@@ -240,12 +249,24 @@ void bench_shmem_iput_latency(int min_msg_size, int max_msg_size, int ntimes,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_iputs and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_iput(dest, source, 1, opts->stride, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_iputs and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
-        shmem_iput(dest, source, 1, stride, elem_count, 1);
+        shmem_iput(dest, source, 1, opts->stride, elem_count, 1);
         shmem_quiet();
 #endif
         double end_time = mysecond();
@@ -254,7 +275,7 @@ void bench_shmem_iput_latency(int min_msg_size, int max_msg_size, int ntimes,
     }
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_iput.h
+++ b/src/benchmarks/rma/shmem_iput.h
@@ -17,19 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_iput
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iput
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_iput_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_iput
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
-  @param stride Stride for shmem_iput
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_iput_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_iput.h
+++ b/src/benchmarks/rma/shmem_iput.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_iput
@@ -21,8 +22,7 @@
   @param ntimes Number of repetitions to get the avgs from
   @param stride Stride for shmem_iput
  */
-void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
-                         int stride);
+void bench_shmem_iput_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_iput
@@ -31,7 +31,6 @@ void bench_shmem_iput_bw(int min_msg_size, int max_msg_size, int ntimes,
   @param ntimes Number of repetitions to get the avgs from
   @param stride Stride for shmem_iput
  */
-void bench_shmem_iput_bibw(int min_msg_size, int max_msg_size, int ntimes,
-                           int stride);
+void bench_shmem_iput_bibw(options * opts);
 
 #endif /* SHMEM_IPUT_H */

--- a/src/benchmarks/rma/shmem_put.c
+++ b/src/benchmarks/rma/shmem_put.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_put_bw(options *opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -52,12 +50,25 @@ void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_put(dest, source, elem_count, 1);
+        shmem_fence();
+#endif
+      }
+      shmem_quiet();
+    }
+
+    shmem_barrier_all();
     /* Start timer */
+    
     start_time = mysecond();
 
     /* Perform ntimes shmem_puts */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_put(dest, source, elem_count, 1);
         shmem_fence();
@@ -70,7 +81,7 @@ void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -98,11 +109,9 @@ void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  */
-void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_put_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -117,11 +126,11 @@ void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -143,12 +152,22 @@ void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
     /* Sync PEs */
     shmem_barrier_all();
+    
+    /* do warmups */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_put(dest, source, elem_count, peer); /* each PE sends to other PE */
+      shmem_fence(); /* ensure ordering of puts */
+#endif
+    }
+
+    shmem_barrier_all();
 
     /* Start timer */
     start_time = mysecond();
 
     /* Perform ntimes bidirectional shmem_puts */
-    for (int j = 0; j < ntimes; j++) {
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_put(dest, source, elem_count, peer); /* each PE sends to other PE */
       shmem_fence(); /* ensure ordering of puts */
@@ -160,7 +179,7 @@ void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
@@ -188,11 +207,9 @@ void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by user 
  *************************************************************/
-void bench_shmem_put_latency(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_put_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -206,11 +223,11 @@ void bench_shmem_put_latency(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -233,9 +250,21 @@ void bench_shmem_put_latency(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_put(dest, source, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Perform ntimes shmem_puts and accumulate total time */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_put(dest, source, elem_count, 1);
@@ -247,7 +276,7 @@ void bench_shmem_put_latency(int min_msg_size, int max_msg_size, int ntimes) {
     }
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_put.h
+++ b/src/benchmarks/rma/shmem_put.h
@@ -17,15 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_put.h
+++ b/src/benchmarks/rma/shmem_put.h
@@ -13,19 +13,20 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_put
   @param min_msg_size Minimum message size for test in bytes
   @param max_msg_size Maximum message size for test in bytes
  */
-void bench_shmem_put_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_put_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put
   @param min_msg_size Minimum message size for test in bytes
   @param max_msg_size Maximum message size for test in bytes
  */
-void bench_shmem_put_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_put_bibw(options * opts);
 
 #endif /* SHMEM_PUT_H */

--- a/src/benchmarks/rma/shmem_put_nbi.c
+++ b/src/benchmarks/rma/shmem_put_nbi.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_put_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -52,12 +50,24 @@ void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_put_nbi(dest, source, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_put_nbis */
+    /* Perform opts->ntimes shmem_put_nbis */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_put_nbi(dest, source, elem_count, 1);
         shmem_quiet();
@@ -69,7 +79,7 @@ void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(valid_size, times[i]);
@@ -97,11 +107,9 @@ void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_put_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -116,11 +124,11 @@ void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -143,11 +151,21 @@ void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_put_nbi(dest, source, elem_count, peer); 
+      shmem_quiet();
+#endif
+    }
+ 
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_put_nbis */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_put_nbis */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_put_nbi(dest, source, elem_count, peer); /* each PE sends to other PE */
       shmem_quiet();
@@ -158,7 +176,7 @@ void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(valid_size, times[i]);
@@ -186,12 +204,9 @@ void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  *************************************************************/
-void bench_shmem_put_nbi_latency(int min_msg_size, int max_msg_size,
-                                 int ntimes) {
+void bench_shmem_put_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -205,11 +220,11 @@ void bench_shmem_put_nbi_latency(int min_msg_size, int max_msg_size,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -232,9 +247,21 @@ void bench_shmem_put_nbi_latency(int min_msg_size, int max_msg_size,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_put_nbis and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_put_nbi(dest, source, elem_count, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_put_nbis and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
         double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
         shmem_put_nbi(dest, source, elem_count, 1);
@@ -249,7 +276,7 @@ void bench_shmem_put_nbi_latency(int min_msg_size, int max_msg_size,
     shmem_barrier_all();
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_put_nbi.c
+++ b/src/benchmarks/rma/shmem_put_nbi.c
@@ -7,7 +7,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -107,7 +107,7 @@ void bench_shmem_put_nbi_bw(options * opts) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -204,7 +204,7 @@ void bench_shmem_put_nbi_bibw(options * opts) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  *************************************************************/
 void bench_shmem_put_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/rma/shmem_put_nbi.h
+++ b/src/benchmarks/rma/shmem_put_nbi.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
@@ -20,7 +21,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_put_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
@@ -28,6 +29,6 @@ void bench_shmem_put_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_put_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_put_nbi_bibw(options * opts);
 
 #endif /* SHMEM_PUT_NBI_H */

--- a/src/benchmarks/rma/shmem_put_nbi.h
+++ b/src/benchmarks/rma/shmem_put_nbi.h
@@ -17,17 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_put_nbi_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_putmem.c
+++ b/src/benchmarks/rma/shmem_putmem.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_putmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
-void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_putmem_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -47,13 +45,25 @@ void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
     /* Sync PEs */
     shmem_barrier_all();
+    
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_putmem(dest, source, size, 1);
+        shmem_fence();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
 
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_puts */
+    /* Perform opts->ntimes shmem_puts */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_putmem(dest, source, size, 1);
         shmem_fence();
@@ -66,7 +76,7 @@ void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / ntimes;
+    times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
     /* Calculate bandwidth using valid size */
     bandwidths[i] = calculate_bw(size, times[i]);
@@ -94,11 +104,9 @@ void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
-void bench_shmem_putmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_putmem_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -113,11 +121,11 @@ void bench_shmem_putmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size */
     msg_sizes[i] = size;
 
@@ -136,11 +144,20 @@ void bench_shmem_putmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+      shmem_putmem(dest, source, size, peer); 
+      shmem_fence();
+#endif
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes bidirectional shmem_puts */
-    for (int j = 0; j < ntimes; j++) {
+    /* Perform opts->ntimes bidirectional shmem_puts */
+    for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
       shmem_putmem(dest, source, size, peer); /* each PE sends to other PE */
       shmem_fence(); /* ensure ordering of puts */
@@ -152,7 +169,7 @@ void bench_shmem_putmem_bibw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
     /* Calculate average time per operation in useconds */
-    times[i] = (end_time - start_time) * 1e6 / (ntimes);
+    times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
     /* Calculate bidirectional bandwidth using valid size */
     bandwidths[i] = calculate_bibw(size, times[i]);

--- a/src/benchmarks/rma/shmem_putmem.h
+++ b/src/benchmarks/rma/shmem_putmem.h
@@ -13,19 +13,20 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_putmem
   @param min_msg_size Minimum message size for test in bytes
   @param max_msg_size Maximum message size for test in bytes
  */
-void bench_shmem_putmem_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_putmem_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_putmem
   @param min_msg_size Minimum message size for test in bytes
   @param max_msg_size Maximum message size for test in bytes
  */
-void bench_shmem_putmem_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_putmem_bibw(options * opts);
 
 #endif /* SHMEM_PUTMEM_H */

--- a/src/benchmarks/rma/shmem_putmem.h
+++ b/src/benchmarks/rma/shmem_putmem.h
@@ -17,15 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_putmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_putmem
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_putmem_nbi.c
+++ b/src/benchmarks/rma/shmem_putmem_nbi.c
@@ -7,11 +7,9 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_putmem_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -25,11 +23,11 @@ void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size and allocate byte buffers */
     msg_sizes[i] = size;
 
@@ -47,12 +45,24 @@ void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    if (mype == 0) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_putmem_nbi(dest, source, size, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-    /* Perform ntimes shmem_putmem_nbis */
+    /* Perform opts->ntimes shmem_putmem_nbis */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
         shmem_putmem_nbi(dest, source, size, 1);
         shmem_quiet();
@@ -64,7 +74,7 @@ void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
     end_time = mysecond();
 
   /* Calculate average time per operation in useconds */
-  times[i] = (end_time - start_time) * 1e6 / ntimes;
+  times[i] = (end_time - start_time) * 1e6 / opts->ntimes;
 
   /* Calculate bandwidth using valid size */
   bandwidths[i] = calculate_bw(size, times[i]);
@@ -92,11 +102,9 @@ void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  */
-void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes) {
+void bench_shmem_putmem_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -111,11 +119,11 @@ void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &bandwidths);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Save message size and allocate byte buffers */
     msg_sizes[i] = size;
 
@@ -133,11 +141,21 @@ void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
     /* Sync PEs */
     shmem_barrier_all();
 
+    /* Do warmup runs */
+    for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+    shmem_putmem_nbi(dest, source, size, peer); /* each PE sends to other PE */
+    shmem_quiet();
+#endif
+  }
+
+    shmem_barrier_all();
+
     /* Start timer */
     start_time = mysecond();
 
-  /* Perform ntimes bidirectional shmem_putmem_nbis */
-  for (int j = 0; j < ntimes; j++) {
+  /* Perform opts->ntimes bidirectional shmem_putmem_nbis */
+  for (int j = 0; j < opts->ntimes; j++) {
 #if defined(USE_14) || defined(USE_15)
     shmem_putmem_nbi(dest, source, size, peer); /* each PE sends to other PE */
     shmem_quiet();
@@ -148,7 +166,7 @@ void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
     end_time = mysecond();
 
   /* Calculate average time per operation in useconds */
-  times[i] = (end_time - start_time) * 1e6 / (ntimes);
+  times[i] = (end_time - start_time) * 1e6 / (opts->ntimes);
 
   /* Calculate bidirectional bandwidth using valid size */
   bandwidths[i] = calculate_bibw(size, times[i]);
@@ -176,12 +194,9 @@ void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes)
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_put_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmarks options given by the user 
  *************************************************************/
-void bench_shmem_putmem_nbi_latency(int min_msg_size, int max_msg_size,
-                                 int ntimes) {
+void bench_shmem_putmem_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */
   if (!check_if_exactly_2_pes()) {
     return;
@@ -195,11 +210,11 @@ void bench_shmem_putmem_nbi_latency(int min_msg_size, int max_msg_size,
   int num_sizes = 0;
 
   /* Setup the benchmark */
-  setup_bench(min_msg_size, max_msg_size, &num_sizes, &msg_sizes, &times,
+  setup_bench(opts->min_msg_size, opts->max_msg_size, &num_sizes, &msg_sizes, &times,
               &latencies);
 
   /* Run the benchmark */
-  for (int i = 0, size = min_msg_size; size <= max_msg_size; size *= 2, i++) {
+  for (int i = 0, size = opts->min_msg_size; size <= opts->max_msg_size; size *= 2, i++) {
     /* Validate the message size for the long datatype */
     int valid_size = validate_typed_size(size, sizeof(long), "long");
     msg_sizes[i] = valid_size;
@@ -222,9 +237,21 @@ void bench_shmem_putmem_nbi_latency(int min_msg_size, int max_msg_size,
     /* Sync PEs */
     shmem_barrier_all();
 
-    /* Perform ntimes shmem_put_nbis and accumulate total time */
+    /* Do warmup runs */
     if (mype == 0) {
-      for (int j = 0; j < ntimes; j++) {
+      for (int j = 0; j < opts->warmups; j++) {
+#if defined(USE_14) || defined(USE_15)
+        shmem_putmem_nbi(dest, source, size, 1);
+        shmem_quiet();
+#endif
+      }
+    }
+
+    shmem_barrier_all();
+
+    /* Perform opts->ntimes shmem_put_nbis and accumulate total time */
+    if (mype == 0) {
+      for (int j = 0; j < opts->ntimes; j++) {
   double start_time = mysecond();
 #if defined(USE_14) || defined(USE_15)
   shmem_putmem_nbi(dest, source, size, 1);
@@ -239,7 +266,7 @@ void bench_shmem_putmem_nbi_latency(int min_msg_size, int max_msg_size,
     shmem_barrier_all();
 
     /* Calculate average latency per operation in microseconds */
-    times[i] = total_time / ntimes;
+    times[i] = total_time / opts->ntimes;
 
     /* Record latency */
     latencies[i] = times[i];

--- a/src/benchmarks/rma/shmem_putmem_nbi.c
+++ b/src/benchmarks/rma/shmem_putmem_nbi.c
@@ -7,7 +7,7 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_nbi_bw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -102,7 +102,7 @@ void bench_shmem_putmem_nbi_bw(options * opts) {
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_nbi_bibw(options * opts) {
   /* Check the number of PEs before doing anything */
@@ -194,7 +194,7 @@ void bench_shmem_putmem_nbi_bibw(options * opts) {
 
 /*************************************************************
   @brief Run the latency benchmark for shmem_put_nbi
-  @param opts Benchmarks options given by the user 
+  @param opts Benchmark options given by the user 
  *************************************************************/
 void bench_shmem_putmem_nbi_latency(options * opts) {
   /* Check the number of PEs before doing anything */

--- a/src/benchmarks/rma/shmem_putmem_nbi.h
+++ b/src/benchmarks/rma/shmem_putmem_nbi.h
@@ -17,17 +17,13 @@
 
 /**
   @brief Run the bandwidth benchmark for shmem_putmem_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_putmem_nbi
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of repetitions to get the avgs from
+  @param opts Benchmark options given by the user 
  */
 void bench_shmem_putmem_nbi_bibw(options * opts);
 

--- a/src/benchmarks/rma/shmem_putmem_nbi.h
+++ b/src/benchmarks/rma/shmem_putmem_nbi.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /**
   @brief Run the bandwidth benchmark for shmem_putmem_nbi
@@ -20,7 +21,7 @@
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_putmem_nbi_bw(options * opts);
 
 /**
   @brief Run the bidirectional bandwidth benchmark for shmem_putmem_nbi
@@ -28,6 +29,6 @@ void bench_shmem_putmem_nbi_bw(int min_msg_size, int max_msg_size, int ntimes);
   @param max_msg_size Maximum message size for test in bytes
   @param ntimes Number of repetitions to get the avgs from
  */
-void bench_shmem_putmem_nbi_bibw(int min_msg_size, int max_msg_size, int ntimes);
+void bench_shmem_putmem_nbi_bibw(options * opts);
 
 #endif /* SHMEM_PUTMEM_NBI_H */

--- a/src/include/parse_opts.h
+++ b/src/include/parse_opts.h
@@ -26,11 +26,15 @@ typedef struct {
   int min_msg_size;
   int max_msg_size;
   int ntimes;
+  int warmups;
   int stride;
 
   /* Option to print help */
   bool help;
 } options;
+
+/* Define default number of warmup iterations */
+#define DEFAULT_WARMUP_ITERATIONS 20
 
 /**
   @brief Parses runtime options
@@ -45,9 +49,7 @@ typedef struct {
   @param stride Stride value to use for the benchmark (only used if applicable)
   @return True if parsing is successful, false otherwise.
  */
-bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
-                char **benchtype, int *min_msg_size, int *max_msg_size,
-                int *ntimes, int *stride);
+bool parse_opts(int argc, char *argv[], options *opts);
 
 /**
   @brief Displays usage information.

--- a/src/include/parse_opts.h
+++ b/src/include/parse_opts.h
@@ -41,12 +41,6 @@ typedef struct {
   @param argc Number of command-line arguments.
   @param argv Array of command-line argument strings.
   @param opts Reference to the test options structure.
-  @param benchmark Routine to be tested (e.g., shmem_put, shmem_get)
-  @param benchtype Type of benchmark to run (bw, bibw, or latency)
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
-  @param stride Stride value to use for the benchmark (only used if applicable)
   @return True if parsing is successful, false otherwise.
  */
 bool parse_opts(int argc, char *argv[], options *opts);

--- a/src/include/shmembench.h
+++ b/src/include/shmembench.h
@@ -48,10 +48,7 @@ int calculate_elem_count(int byte_size, size_t type_size);
   @param benchmark The benchmark to be run (e.g., "shmem_put", "shmem_get")
   @param benchtype The type of benchmark to run, either "bw", "bibw", or
   "latency"
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
-  @param stride Stride value to use for the benchmark (only applicable to
+  @param opts Benchmark options given by the user 
   certain benchmarks)
  */
 void run_benchmark(options * opts);

--- a/src/include/shmembench.h
+++ b/src/include/shmembench.h
@@ -15,6 +15,7 @@
 #include <sys/time.h>
 
 #include "benchmarks.h"
+#include "parse_opts.h"
 
 /* ANSI color codes for pretty output */
 #define RESET_COLOR "\033[0m"
@@ -53,8 +54,7 @@ int calculate_elem_count(int byte_size, size_t type_size);
   @param stride Stride value to use for the benchmark (only applicable to
   certain benchmarks)
  */
-void run_benchmark(char *benchmark, char *benchtype, int min_msg_size,
-                   int max_msg_size, int ntimes, int stride);
+void run_benchmark(options * opts);
 
 /**
   @brief Calculate bandwidth based on message size and time

--- a/src/main.c
+++ b/src/main.c
@@ -60,12 +60,11 @@ int main(int argc, char *argv[]) {
     Parse options
   */
   options opts;
-  char *benchmark = (char *)malloc(100 * sizeof(char));
-  char *benchtype = (char *)malloc(100 * sizeof(char));
-  int min_msg_size, max_msg_size;
-  int ntimes, stride;
+  opts.bench = (char *)malloc(100 * sizeof(char));
+  opts.benchtype = (char *)malloc(100 * sizeof(char));
+  /* int min_msg_size, max_msg_size; */
+  /* int ntimes, stride; */
   shmem_barrier_all();
-
   if (argc == 1) {
     if (mype == 0) {
       display_help();
@@ -74,8 +73,7 @@ int main(int argc, char *argv[]) {
     return EXIT_SUCCESS;
   }
 
-  if (!parse_opts(argc, argv, &opts, &benchmark, &benchtype, &min_msg_size,
-                  &max_msg_size, &ntimes, &stride)) {
+  if (!parse_opts(argc, argv, &opts)) {
     if (mype == 0) {
       display_help();
     }
@@ -99,24 +97,23 @@ int main(int argc, char *argv[]) {
   */
   shmem_barrier_all();
   if (mype == 0) {
-    display_header(name, version, npes, benchmark, benchtype, min_msg_size,
-                   max_msg_size, ntimes, stride);
+    display_header(name, version, npes, opts.bench, opts.benchtype, opts.min_msg_size,
+                   opts.max_msg_size, opts.ntimes, opts.stride);
   }
 
   /**
     Run benchmarks
   */
   shmem_barrier_all();
-  run_benchmark(benchmark, benchtype, min_msg_size, max_msg_size, ntimes,
-                stride);
+  run_benchmark(&opts);
 
   /**
     Finalize the program
   */
   free(version);
   free(name);
-  free(benchmark);
-  free(benchtype);
+  free(opts.bench);
+  free(opts.benchtype);
 
   shmem_finalize();
   return EXIT_SUCCESS;

--- a/src/parse_opts.c
+++ b/src/parse_opts.c
@@ -1,7 +1,5 @@
 /**
-  @file parse_opts.c
-  @details Parse the runtime options from the command line
-  @author Michael Beebe (Texas Tech University)
+  @file parse_opts.c @details Parse the runtime options from the command line @author Michael Beebe (Texas Tech University)
  */
 
 #include "parse_opts.h"
@@ -19,17 +17,23 @@
   @param stride Stride value to use for the benchmark (only used if applicable)
   @return True if parsing is successful, false otherwise.
  */
-bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
-                char **benchtype, int *min_msg_size, int *max_msg_size,
-                int *ntimes, int *stride) {
+bool parse_opts(int argc, char *argv[], options *opts) {
   /* Initialize all options to default values */
   memset(opts, 0, sizeof(*opts));
 
+  /* Set default value for Warmup Rounds */
+
+  opts->warmups = DEFAULT_WARMUP_ITERATIONS;
+
   /* Set default values for min_msg_size, max_msg_size, ntimes, and stride */
-  *min_msg_size = 8;
-  *max_msg_size = 1024;
-  *ntimes = 10;
-  *stride = 10;
+  opts->min_msg_size = 8;
+  opts->max_msg_size = 1024;
+  opts->ntimes = 10;
+  opts->stride = 10;
+
+  /* Set bench and benchtype to NULL */
+  opts->bench = NULL;
+  opts->benchtype = NULL;
 
   /* Define runtime options */
   static struct option long_options[] = {
@@ -38,6 +42,7 @@ bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
       {"min", required_argument, 0, 0},
       {"max", required_argument, 0, 0},
       {"ntimes", required_argument, 0, 0},
+      {"warmup", required_argument, 0, 0},
       {"stride", required_argument, 0, 0},
       {"help", no_argument, 0, 0},
       {0, 0, 0, 0} /* Terminator */
@@ -54,12 +59,10 @@ bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
 
       if (strcmp(option_name, "bench") == 0) {
         opts->bench = strdup(optarg);
-        *benchmark = opts->bench;
       } else if (strcmp(option_name, "benchtype") == 0) {
         if (strcmp(optarg, "bw") == 0 || strcmp(optarg, "bibw") == 0 ||
             strcmp(optarg, "latency") == 0) {
           opts->benchtype = strdup(optarg);
-          *benchtype = opts->benchtype;
         } else {
           if (shmem_my_pe() == 0) {
             fprintf(stderr,
@@ -70,37 +73,38 @@ bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
           return false;
         }
       } else if (strcmp(option_name, "min") == 0) {
-        if (*benchmark && (strcmp(*benchmark, "shmem_barrier_all") != 0)) {
+        if (opts->bench && (strcmp(opts->bench, "shmem_barrier_all") != 0)) {
           opts->min_msg_size = atoi(optarg);
           if (opts->min_msg_size <= 0) {
             opts->min_msg_size = 1; /* Set a default if not provided */
           }
-          *min_msg_size = opts->min_msg_size;
         }
       } else if (strcmp(option_name, "max") == 0) {
-        if (*benchmark && (strcmp(*benchmark, "shmem_barrier_all") != 0)) {
+        if (opts->bench && (strcmp(opts->bench, "shmem_barrier_all") != 0)) {
           opts->max_msg_size = atoi(optarg);
           if (opts->max_msg_size <= 0 ||
               opts->max_msg_size < opts->min_msg_size) {
             opts->max_msg_size =
-                *min_msg_size * 128; /* Set a default max if invalid */
+                opts->min_msg_size * 128; /* Set a default max if invalid */
           }
-          *max_msg_size = opts->max_msg_size;
         }
       } else if (strcmp(option_name, "ntimes") == 0) {
         opts->ntimes = atoi(optarg);
         if (opts->ntimes <= 0) {
           opts->ntimes = 10; /* Default to 10 if not provided */
         }
-        *ntimes = opts->ntimes;
+      } else if (strcmp(option_name, "warmups") == 0) {
+        opts->warmups = atoi(optarg);
+        if (opts->warmups < 0){
+          opts->warmups = DEFAULT_WARMUP_ITERATIONS;
+        }
       } else if (strcmp(option_name, "stride") == 0) {
-        if (*benchmark && (strcmp(*benchmark, "shmem_iput") == 0 ||
-                           strcmp(*benchmark, "shmem_iget") == 0)) {
+        if (opts->bench && (strcmp(opts->bench, "shmem_iput") == 0 ||
+                           strcmp(opts->bench, "shmem_iget") == 0)) {
           opts->stride = atoi(optarg);
           if (opts->stride <= 0) {
             opts->stride = 10; /* Default to 10 if not provided */
           }
-          *stride = opts->stride;
         }
       } else if (strcmp(option_name, "help") == 0) {
         opts->help = true;
@@ -112,46 +116,45 @@ bool parse_opts(int argc, char *argv[], options *opts, char **benchmark,
     }
   }
 
-  /* Set default benchtype if not provided by user */
-  if (*benchtype == NULL || strlen(*benchtype) == 0) {
-    if (*benchmark != NULL) {
-      /* Atomics: default to latency */
-      if (strstr(*benchmark, "atomic") != NULL) {
-        opts->benchtype = strdup("latency");
-        *benchtype = opts->benchtype;
-      }
-      /* Barrier: default to latency */
-      else if (strcmp(*benchmark, "shmem_barrier_all") == 0) {
-        opts->benchtype = strdup("latency");
-        *benchtype = opts->benchtype;
-      }
-      /* Collectives and pt2pt RMA: default to bw */
-      else if (strcmp(*benchmark, "shmem_put") == 0 ||
-               strcmp(*benchmark, "shmem_putmem") == 0 ||
-               strcmp(*benchmark, "shmem_iput") == 0 ||
-               strcmp(*benchmark, "shmem_get") == 0 ||
-               strcmp(*benchmark, "shmem_getmem") == 0 ||
-               strcmp(*benchmark, "shmem_iget") == 0 ||
-               strcmp(*benchmark, "shmem_put_nbi") == 0 ||
-               strcmp(*benchmark, "shmem_putmem_nbi") == 0 ||
-               strcmp(*benchmark, "shmem_get_nbi") == 0 ||
-               strcmp(*benchmark, "shmem_getmem_nbi") == 0 ||
-               strcmp(*benchmark, "shmem_alltoall") == 0 ||
-               strcmp(*benchmark, "shmem_alltoallmem") == 0 ||
-               strcmp(*benchmark, "shmem_alltoalls") == 0 ||
-               strcmp(*benchmark, "shmem_alltoallsmem") == 0 ||
-               strcmp(*benchmark, "shmem_broadcast") == 0 ||
-               strcmp(*benchmark, "shmem_broadcastmem") == 0 ||
-               strcmp(*benchmark, "shmem_collectmem") == 0 ||
-               strcmp(*benchmark, "shmem_collect") == 0 ||
-               strcmp(*benchmark, "shmem_fcollect") == 0 ||
-               strcmp(*benchmark, "shmem_fcollectmem") == 0) {
-        opts->benchtype = strdup("bw");
-        *benchtype = opts->benchtype;
-      }
-    }
+  /* return false if benchmark not specified */
+  if (opts->bench == NULL){
+    return false;
   }
 
+  /* Set default benchtype if not provided by user */
+  if (opts->benchtype == NULL || strlen(opts->bench) == 0) {
+    /* Atomics: default to latency */
+    if (strstr(opts->bench, "atomic") != NULL) {
+      opts->benchtype = strdup("latency");
+    }
+    /* Barrier: default to latency */
+    else if (strcmp(opts->bench, "shmem_barrier_all") == 0) {
+      opts->benchtype = strdup("latency");
+    }
+    /* Collectives and pt2pt RMA: default to bw */
+    else if (strcmp(opts->bench, "shmem_put") == 0 ||
+             strcmp(opts->bench, "shmem_putmem") == 0 ||
+             strcmp(opts->bench, "shmem_iput") == 0 ||
+             strcmp(opts->bench, "shmem_get") == 0 ||
+             strcmp(opts->bench, "shmem_getmem") == 0 ||
+             strcmp(opts->bench, "shmem_iget") == 0 ||
+             strcmp(opts->bench, "shmem_put_nbi") == 0 ||
+             strcmp(opts->bench, "shmem_putmem_nbi") == 0 ||
+             strcmp(opts->bench, "shmem_get_nbi") == 0 ||
+             strcmp(opts->bench, "shmem_getmem_nbi") == 0 ||
+             strcmp(opts->bench, "shmem_alltoall") == 0 ||
+             strcmp(opts->bench, "shmem_alltoallmem") == 0 ||
+             strcmp(opts->bench, "shmem_alltoalls") == 0 ||
+             strcmp(opts->bench, "shmem_alltoallsmem") == 0 ||
+             strcmp(opts->bench, "shmem_broadcast") == 0 ||
+             strcmp(opts->bench, "shmem_broadcastmem") == 0 ||
+             strcmp(opts->bench, "shmem_collectmem") == 0 ||
+             strcmp(opts->bench, "shmem_collect") == 0 ||
+             strcmp(opts->bench, "shmem_fcollect") == 0 ||
+             strcmp(opts->bench, "shmem_fcollectmem") == 0) {
+      opts->benchtype = strdup("bw");
+    }
+  }
   return true;
 }
 

--- a/src/parse_opts.c
+++ b/src/parse_opts.c
@@ -9,12 +9,6 @@
   @param argc Number of command-line arguments.
   @param argv Array of command-line argument strings.
   @param opts Reference to the test options structure.
-  @param benchmark Routine to be tested (e.g., shmem_put, shmem_get)
-  @param benchtype Type of benchmark to run (bw, bibw, or latency)
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
-  @param stride Stride value to use for the benchmark (only used if applicable)
   @return True if parsing is successful, false otherwise.
  */
 bool parse_opts(int argc, char *argv[], options *opts) {

--- a/src/shmembench.c
+++ b/src/shmembench.c
@@ -4,18 +4,17 @@
  */
 
 #include "shmembench.h"
+#include "parse_opts.h"
 
 /* Function pointer type for benchmarks without stride */
-typedef void (*benchmark_func_t)(int min_msg_size, int max_msg_size,
-                                 int ntimes);
+typedef void (*benchmark_func_t)(options *opts);
 
 /* Function pointer type for benchmarks with stride */
-typedef void (*benchmark_func_with_stride_t)(int min_msg_size, int max_msg_size,
-                                             int ntimes, int stride);
+typedef void (*benchmark_func_with_stride_t)(options * opts);
 
 /* Function pointer type for benchmarks without message size parameters (like
  * barriers and atomics) */
-typedef void (*benchmark_func_no_size_t)(int ntimes);
+typedef void (*benchmark_func_no_size_t)(options * opts);
 
 /* Mapping of benchmarks and their types to functions */
 typedef struct {
@@ -30,49 +29,49 @@ typedef struct {
 /* Dispatch table for benchmarks */
 benchmark_entry_t benchmark_table[] = {
     {"shmem_put", "bw", bench_shmem_put_bw, NULL, NULL, false},
-    {"shmem_put", "bibw", bench_shmem_put_bibw, NULL, NULL, false},
+    {"shmem_put", "bibw", bench_shmem_put_bibw, NULL, NULL, false}, // done
 
     {"shmem_get", "bw", bench_shmem_get_bw, NULL, NULL, false},
-    {"shmem_get", "bibw", bench_shmem_get_bibw, NULL, NULL, false},
+    {"shmem_get", "bibw", bench_shmem_get_bibw, NULL, NULL, false}, // done
 
     {"shmem_putmem", "bw", bench_shmem_putmem_bw, NULL, NULL, false},
-    {"shmem_putmem", "bibw", bench_shmem_putmem_bibw, NULL, NULL, false},
+    {"shmem_putmem", "bibw", bench_shmem_putmem_bibw, NULL, NULL, false}, // done
 
     {"shmem_getmem", "bw", bench_shmem_getmem_bw, NULL, NULL, false},
-    {"shmem_getmem", "bibw", bench_shmem_getmem_bibw, NULL, NULL, false},
+    {"shmem_getmem", "bibw", bench_shmem_getmem_bibw, NULL, NULL, false}, // done
 
     {"shmem_iput", "bw", NULL, bench_shmem_iput_bw, NULL, true},
-    {"shmem_iput", "bibw", NULL, bench_shmem_iput_bibw, NULL, true},
-
+    {"shmem_iput", "bibw", NULL, bench_shmem_iput_bibw, NULL, true}, // done
+ 
     {"shmem_iget", "bw", NULL, bench_shmem_iget_bw, NULL, true},
-    {"shmem_iget", "bibw", NULL, bench_shmem_iget_bibw, NULL, true},
+    {"shmem_iget", "bibw", NULL, bench_shmem_iget_bibw, NULL, true}, // done 2
 
     {"shmem_put_nbi", "bw", bench_shmem_put_nbi_bw, NULL, NULL, false},
-    {"shmem_put_nbi", "bibw", bench_shmem_put_nbi_bibw, NULL, NULL, false},
+    {"shmem_put_nbi", "bibw", bench_shmem_put_nbi_bibw, NULL, NULL, false}, // done 2
 
     {"shmem_get_nbi", "bw", bench_shmem_get_nbi_bw, NULL, NULL, false},
-    {"shmem_get_nbi", "bibw", bench_shmem_get_nbi_bibw, NULL, NULL, false},
+    {"shmem_get_nbi", "bibw", bench_shmem_get_nbi_bibw, NULL, NULL, false}, //done 2
 
     {"shmem_putmem_nbi", "bw", bench_shmem_putmem_nbi_bw, NULL, NULL, false},
-    {"shmem_putmem_nbi", "bibw", bench_shmem_putmem_nbi_bibw, NULL, NULL, false},
+    {"shmem_putmem_nbi", "bibw", bench_shmem_putmem_nbi_bibw, NULL, NULL, false}, // done 2
 
     {"shmem_getmem_nbi", "bw", bench_shmem_getmem_nbi_bw, NULL, NULL, false},
-    {"shmem_getmem_nbi", "bibw", bench_shmem_getmem_nbi_bibw, NULL, NULL, false},
+    {"shmem_getmem_nbi", "bibw", bench_shmem_getmem_nbi_bibw, NULL, NULL, false}, // done
 
-    {"shmem_alltoall", "bw", bench_shmem_alltoall_bw, NULL, NULL, false},
-    {"shmem_alltoallmem", "bw", bench_shmem_alltoallmem_bw, NULL, NULL, false},
+    {"shmem_alltoall", "bw", bench_shmem_alltoall_bw, NULL, NULL, false}, // done 3
+    {"shmem_alltoallmem", "bw", bench_shmem_alltoallmem_bw, NULL, NULL, false}, // done 3
 
-    {"shmem_alltoalls", "bw", bench_shmem_alltoalls_bw, NULL, NULL, false},
-    {"shmem_alltoallsmem", "bw", bench_shmem_alltoallsmem_bw, NULL, NULL, false},
+    {"shmem_alltoalls", "bw", bench_shmem_alltoalls_bw, NULL, NULL, false}, // done 3
+    {"shmem_alltoallsmem", "bw", bench_shmem_alltoallsmem_bw, NULL, NULL, false}, // done 3
 
-    {"shmem_broadcast", "bw", bench_shmem_broadcast_bw, NULL, NULL, false},
-    {"shmem_broadcastmem", "bw", bench_shmem_broadcastmem_bw, NULL, NULL, false},
+    {"shmem_broadcast", "bw", bench_shmem_broadcast_bw, NULL, NULL, false}, // done 3
+    {"shmem_broadcastmem", "bw", bench_shmem_broadcastmem_bw, NULL, NULL, false}, // done 3
 
-    {"shmem_collect", "bw", bench_shmem_collect_bw, NULL, NULL, false},
-    {"shmem_collectmem", "bw", bench_shmem_collectmem_bw, NULL, NULL, false},
+    {"shmem_collect", "bw", bench_shmem_collect_bw, NULL, NULL, false}, // done 3
+    {"shmem_collectmem", "bw", bench_shmem_collectmem_bw, NULL, NULL, false}, // done 3
 
-    {"shmem_fcollect", "bw", bench_shmem_fcollect_bw, NULL, NULL, false},
-    {"shmem_fcollectmem", "bw", bench_shmem_fcollectmem_bw, NULL, NULL, false},
+    {"shmem_fcollect", "bw", bench_shmem_fcollect_bw, NULL, NULL, false}, // done 3
+    {"shmem_fcollectmem", "bw", bench_shmem_fcollectmem_bw, NULL, NULL, false}, // done 3
 
     {"shmem_barrier_all", "latency", NULL, NULL,
      bench_shmem_barrier_all_latency, false},
@@ -102,19 +101,17 @@ benchmark_entry_t benchmark_table[] = {
   @param ntimes Number of times the benchmark should run
   @param stride Stride value to use for the benchmark (only used if applicable)
  */
-void run_benchmark(char *benchmark, char *benchtype, int min_msg_size,
-                   int max_msg_size, int ntimes, int stride) {
+void run_benchmark(options * opts) {
   for (int i = 0; i < sizeof(benchmark_table) / sizeof(benchmark_entry_t);
        i++) {
-    if (strcmp(benchmark, benchmark_table[i].benchmark) == 0 &&
-        strcmp(benchtype, benchmark_table[i].benchtype) == 0) {
+    if (strcmp(opts->bench, benchmark_table[i].benchmark) == 0 &&
+        strcmp(opts->benchtype, benchmark_table[i].benchtype) == 0) {
       if (benchmark_table[i].uses_stride) {
-        benchmark_table[i].func_with_stride(min_msg_size, max_msg_size, ntimes,
-                                            stride);
+        benchmark_table[i].func_with_stride(opts);
       } else if (benchmark_table[i].func != NULL) {
-        benchmark_table[i].func(min_msg_size, max_msg_size, ntimes);
+        benchmark_table[i].func(opts);
       } else if (benchmark_table[i].func_no_size != NULL) {
-        benchmark_table[i].func_no_size(ntimes);
+        benchmark_table[i].func_no_size(opts);
       }
       return;
     }

--- a/src/shmembench.c
+++ b/src/shmembench.c
@@ -93,13 +93,7 @@ benchmark_entry_t benchmark_table[] = {
 
 /**
   @brief Run the selected benchmark
-  @param benchmark The benchmark to be run (e.g., "shmem_put", "shmem_get")
-  @param benchtype The type of benchmark to run, either "bw", "bibw", or
- "latency"
-  @param min_msg_size Minimum message size for test in bytes
-  @param max_msg_size Maximum message size for test in bytes
-  @param ntimes Number of times the benchmark should run
-  @param stride Stride value to use for the benchmark (only used if applicable)
+  @param opts Benchmark options given by the user 
  */
 void run_benchmark(options * opts) {
   for (int i = 0; i < sizeof(benchmark_table) / sizeof(benchmark_entry_t);

--- a/src/shmembench.c
+++ b/src/shmembench.c
@@ -29,67 +29,67 @@ typedef struct {
 /* Dispatch table for benchmarks */
 benchmark_entry_t benchmark_table[] = {
     {"shmem_put", "bw", bench_shmem_put_bw, NULL, NULL, false},
-    {"shmem_put", "bibw", bench_shmem_put_bibw, NULL, NULL, false}, // done
+    {"shmem_put", "bibw", bench_shmem_put_bibw, NULL, NULL, false}, 
 
     {"shmem_get", "bw", bench_shmem_get_bw, NULL, NULL, false},
-    {"shmem_get", "bibw", bench_shmem_get_bibw, NULL, NULL, false}, // done
+    {"shmem_get", "bibw", bench_shmem_get_bibw, NULL, NULL, false}, 
 
     {"shmem_putmem", "bw", bench_shmem_putmem_bw, NULL, NULL, false},
-    {"shmem_putmem", "bibw", bench_shmem_putmem_bibw, NULL, NULL, false}, // done
+    {"shmem_putmem", "bibw", bench_shmem_putmem_bibw, NULL, NULL, false}, 
 
     {"shmem_getmem", "bw", bench_shmem_getmem_bw, NULL, NULL, false},
-    {"shmem_getmem", "bibw", bench_shmem_getmem_bibw, NULL, NULL, false}, // done
+    {"shmem_getmem", "bibw", bench_shmem_getmem_bibw, NULL, NULL, false}, 
 
     {"shmem_iput", "bw", NULL, bench_shmem_iput_bw, NULL, true},
-    {"shmem_iput", "bibw", NULL, bench_shmem_iput_bibw, NULL, true}, // done
+    {"shmem_iput", "bibw", NULL, bench_shmem_iput_bibw, NULL, true}, 
  
     {"shmem_iget", "bw", NULL, bench_shmem_iget_bw, NULL, true},
-    {"shmem_iget", "bibw", NULL, bench_shmem_iget_bibw, NULL, true}, // done 2
+    {"shmem_iget", "bibw", NULL, bench_shmem_iget_bibw, NULL, true}, 
 
     {"shmem_put_nbi", "bw", bench_shmem_put_nbi_bw, NULL, NULL, false},
-    {"shmem_put_nbi", "bibw", bench_shmem_put_nbi_bibw, NULL, NULL, false}, // done 2
+    {"shmem_put_nbi", "bibw", bench_shmem_put_nbi_bibw, NULL, NULL, false},
 
     {"shmem_get_nbi", "bw", bench_shmem_get_nbi_bw, NULL, NULL, false},
-    {"shmem_get_nbi", "bibw", bench_shmem_get_nbi_bibw, NULL, NULL, false}, //done 2
+    {"shmem_get_nbi", "bibw", bench_shmem_get_nbi_bibw, NULL, NULL, false},
 
     {"shmem_putmem_nbi", "bw", bench_shmem_putmem_nbi_bw, NULL, NULL, false},
-    {"shmem_putmem_nbi", "bibw", bench_shmem_putmem_nbi_bibw, NULL, NULL, false}, // done 2
+    {"shmem_putmem_nbi", "bibw", bench_shmem_putmem_nbi_bibw, NULL, NULL, false},
 
     {"shmem_getmem_nbi", "bw", bench_shmem_getmem_nbi_bw, NULL, NULL, false},
-    {"shmem_getmem_nbi", "bibw", bench_shmem_getmem_nbi_bibw, NULL, NULL, false}, // done
+    {"shmem_getmem_nbi", "bibw", bench_shmem_getmem_nbi_bibw, NULL, NULL, false}, 
 
-    {"shmem_alltoall", "bw", bench_shmem_alltoall_bw, NULL, NULL, false}, // done 3
-    {"shmem_alltoallmem", "bw", bench_shmem_alltoallmem_bw, NULL, NULL, false}, // done 3
+    {"shmem_alltoall", "bw", bench_shmem_alltoall_bw, NULL, NULL, false}, 
+    {"shmem_alltoallmem", "bw", bench_shmem_alltoallmem_bw, NULL, NULL, false},
 
-    {"shmem_alltoalls", "bw", bench_shmem_alltoalls_bw, NULL, NULL, false}, // done 3
-    {"shmem_alltoallsmem", "bw", bench_shmem_alltoallsmem_bw, NULL, NULL, false}, // done 3
+    {"shmem_alltoalls", "bw", bench_shmem_alltoalls_bw, NULL, NULL, false},
+    {"shmem_alltoallsmem", "bw", bench_shmem_alltoallsmem_bw, NULL, NULL, false},
 
-    {"shmem_broadcast", "bw", bench_shmem_broadcast_bw, NULL, NULL, false}, // done 3
-    {"shmem_broadcastmem", "bw", bench_shmem_broadcastmem_bw, NULL, NULL, false}, // done 3
+    {"shmem_broadcast", "bw", bench_shmem_broadcast_bw, NULL, NULL, false}, 
+    {"shmem_broadcastmem", "bw", bench_shmem_broadcastmem_bw, NULL, NULL, false}, 
 
-    {"shmem_collect", "bw", bench_shmem_collect_bw, NULL, NULL, false}, // done 3
-    {"shmem_collectmem", "bw", bench_shmem_collectmem_bw, NULL, NULL, false}, // done 3
+    {"shmem_collect", "bw", bench_shmem_collect_bw, NULL, NULL, false}, 
+    {"shmem_collectmem", "bw", bench_shmem_collectmem_bw, NULL, NULL, false}, 
 
-    {"shmem_fcollect", "bw", bench_shmem_fcollect_bw, NULL, NULL, false}, // done 3
-    {"shmem_fcollectmem", "bw", bench_shmem_fcollectmem_bw, NULL, NULL, false}, // done 3
+    {"shmem_fcollect", "bw", bench_shmem_fcollect_bw, NULL, NULL, false},
+    {"shmem_fcollectmem", "bw", bench_shmem_fcollectmem_bw, NULL, NULL, false},
 
     {"shmem_barrier_all", "latency", NULL, NULL,
      bench_shmem_barrier_all_latency, false},
 
     {"shmem_atomic_add", "latency", NULL, NULL, bench_shmem_atomic_add_latency,
-     false},
+     false}, 
     {"shmem_atomic_compare_swap", "latency", NULL, NULL,
-     bench_shmem_atomic_compare_swap_latency, false},
+     bench_shmem_atomic_compare_swap_latency, false}, 
     {"shmem_atomic_fetch_nbi", "latency", NULL, NULL,
-     bench_shmem_atomic_fetch_nbi_latency, false},
+     bench_shmem_atomic_fetch_nbi_latency, false}, 
     {"shmem_atomic_fetch", "latency", NULL, NULL,
-     bench_shmem_atomic_fetch_latency, false},
+     bench_shmem_atomic_fetch_latency, false}, 
     {"shmem_atomic_inc", "latency", NULL, NULL, bench_shmem_atomic_inc_latency,
-     false},
+     false}, 
     {"shmem_atomic_set", "latency", NULL, NULL, bench_shmem_atomic_set_latency,
-     false},
+     false}, 
     {"shmem_atomic_swap", "latency", NULL, NULL,
-     bench_shmem_atomic_swap_latency, false}};
+     bench_shmem_atomic_swap_latency, false}}; 
 
 /**
   @brief Run the selected benchmark


### PR DESCRIPTION
Changes:

- Updated all benchmarks to have warmup iterations. Number of iterations can be specified by the --warmup flag and defaults to 20 when no argument is supplied by the user. Default value is specified in the DEFAULT_WARMUP_ITERATIONS macro located in the parse_ops.h header file.
- Removed the redundant max_msg_size, min_msg_size, ntimes, and strides variables. The parsing routine now just uses the * opts parameter. 
- All benchmark routines now also take the * opts parameter to allow for more flexibility. Header files were updated accordingly.
- Fixed input validation to ensure the parse_opts routine returns false when no --bench flag is supplied.
- Fixed the alltoalls and the alltoalls_mem benchmark (was getting an overlapping symmetric memory error).